### PR TITLE
feat: add label filter to reduce scope of action

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,19 @@ Add the PR creator as assignee to the pull request.
 addAssignees: author
 ```
 
-### Specify labels the PR must have
-The action will only run if the PR has any of the specified labels
+### Filter by label
+The action will only run if the PR meets the specified filters
 
 ```yaml
-labels:
-  - my_label
-  - another_label
+filterLabels:
+  # Run
+  include:
+    - my_label
+    - another_label
+  # Not run
+  exclude:
+    - wip
+
 ```
 
 ## :memo: Licence

--- a/README.md
+++ b/README.md
@@ -115,5 +115,14 @@ Add the PR creator as assignee to the pull request.
 addAssignees: author
 ```
 
+### Specify labels the PR must have
+The action will only run if the PR has any of the specified labels
+
+```yaml
+labels:
+  - my_label
+  - another_label
+```
+
 ## :memo: Licence
 MIT

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -20,6 +20,7 @@ describe('handlePullRequest', () => {
         number: '1',
         pull_request: {
           number: 1,
+          labels: [],
           title: 'test',
           user: {
             login: 'pr-creator',
@@ -831,11 +832,7 @@ describe('handlePullRequest', () => {
       labels: ['test_label'],
     } as any
 
-    client.issues = {
-      listLabelsOnIssue: jest
-        .fn()
-        .mockResolvedValue({ data: [{ name: 'some_label' }] }),
-    } as any
+    context.payload.pull_request.labels = [{ name: 'some_label' }]
 
     await handler.handlePullRequest(client, context, config)
 
@@ -855,12 +852,7 @@ describe('handlePullRequest', () => {
 
     const client = new github.GitHub('token')
 
-    client.issues = {
-      addAssignees: jest.fn().mockImplementation(async () => {}),
-      listLabelsOnIssue: jest
-        .fn()
-        .mockResolvedValue({ data: [{ name: 'some_label' }] }),
-    } as any
+    context.payload.pull_request.labels = [{ name: 'some_label' }]
 
     client.pulls = {
       createReviewRequest: jest.fn().mockImplementation(async () => {}),

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -9,6 +9,7 @@ export interface Config {
   addAssignees: boolean | string
   reviewers: string[]
   assignees: string[]
+  labels?: string[]
   numberOfAssignees: number
   numberOfReviewers: number
   skipKeywords: string[]
@@ -36,6 +37,7 @@ export async function handlePullRequest(
     assigneeGroups,
     addReviewers,
     addAssignees,
+    labels,
   } = config
 
   if (skipKeywords && utils.includesSkipKeywords(title, skipKeywords)) {
@@ -65,6 +67,16 @@ export async function handlePullRequest(
 
   const owner = user.login
   const pr = new PullRequest(client, context)
+
+  if (labels !== undefined && labels.length > 0) {
+    const hasLabels = await pr.hasAnyLabel(labels)
+    if (!hasLabels) {
+      core.info(
+        'Skips the process to add reviewers/assignees since PR is not tagged with any of the labels'
+      )
+      return
+    }
+  }
 
   if (addReviewers) {
     try {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -69,7 +69,7 @@ export async function handlePullRequest(
   const pr = new PullRequest(client, context)
 
   if (labels !== undefined && labels.length > 0) {
-    const hasLabels = await pr.hasAnyLabel(labels)
+    const hasLabels = pr.hasAnyLabel(labels)
     if (!hasLabels) {
       core.info(
         'Skips the process to add reviewers/assignees since PR is not tagged with any of the labels'

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -32,4 +32,14 @@ export class PullRequest {
     })
     core.debug(JSON.stringify(result))
   }
+
+  async hasAnyLabel(labels: string[]): Promise<boolean> {
+    const { owner, repo, number: pull_number } = this.context.issue
+    const pullRequestLabels = (await this.client.issues.listLabelsOnIssue({
+      number: pull_number,
+      owner,
+      repo,
+    })).data
+    return pullRequestLabels.some(label => labels.includes(label.name))
+  }
 }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -36,7 +36,7 @@ export class PullRequest {
   async hasAnyLabel(labels: string[]): Promise<boolean> {
     const { owner, repo, number: pull_number } = this.context.issue
     const pullRequestLabels = (await this.client.issues.listLabelsOnIssue({
-      number: pull_number,
+      issue_number: pull_number,
       owner,
       repo,
     })).data

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -33,13 +33,11 @@ export class PullRequest {
     core.debug(JSON.stringify(result))
   }
 
-  async hasAnyLabel(labels: string[]): Promise<boolean> {
-    const { owner, repo, number: pull_number } = this.context.issue
-    const pullRequestLabels = (await this.client.issues.listLabelsOnIssue({
-      issue_number: pull_number,
-      owner,
-      repo,
-    })).data
+  hasAnyLabel(labels: string[]): boolean {
+    if (!this.context.payload.pull_request) {
+      return false
+    }
+    const { labels: pullRequestLabels = [] } = this.context.payload.pull_request
     return pullRequestLabels.some(label => labels.includes(label.name))
   }
 }


### PR DESCRIPTION
Thanks for this really cool action! I started to use it, but realized that I needed it to only run in PRs that had certain labels.

This PR adds support to specify a list of labels that a pull request must have to trigger the action. If the target PR doesn't have any of the specified labels, then the action is skipped.

