### PR TITLE
add repo-token in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.0
         with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: ".github/some_name_for_configs.yml" # Only needed if you use something other than .github/auto_assign.yml
 ```
 


### PR DESCRIPTION
The usage example is missing the required input `repo-token`