### PR TITLE
Add section about not assigning when an assignee is already present to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,17 @@ filterLabels:
 
 ```
 
+### Don't assign when an assignee is already present
+By default, the assignee gets overwritten every time the job is executed. You can add a check to skip the job when an assignee is already present:
+
+```yaml
+jobs:
+  add-reviews:
+    if: github.event.pull_request.requested_reviewers.*.name == ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.0
+```
+
 ## :memo: Licence
 MIT


### PR DESCRIPTION
resolves #16 