### PR TITLE
Include repo-token in example workflow definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: ".github/some_name_for_configs.yml" # Only needed if you use something other than .github/auto_assign.yml
 ```
 


### PR DESCRIPTION
The `repo-token` variable is required for the action to access the GitHub API and change the PR. You should include it in the example workflow definition in the `README.md`.