### PR TITLE
Update trigger event to pull_request_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create a workflow (e.g. `.github/workflows/action.yml` For more detail, refer to
 
 ```yml
 name: 'Auto Assign'
-on: pull_request
+on: pull_request_target
 
 jobs:
   add-reviews:


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target which explains why this way the action has all the necessary permissions.

Fixes https://github.com/kentaro-m/auto-assign-action/issues/29