### PR TITLE
Updating example with most probable config for running action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Create a workflow (e.g. `.github/workflows/action.yml` For more detail, refer to
 
 ```yml
 name: 'Auto Assign'
-on: pull_request
+on:
+  pull_request
+    types: [opened, ready_for_review]
 
 jobs:
   add-reviews:


### PR DESCRIPTION
The default example snippet for action.yml runs the action on every new commit added to the PR and hence keeps adding +1 reviewer everytime. But I think the most possible usecase would be to add reviewer when PR is first opened or when a draft PR is marked as ready.

Accordingly updated the example