### PR TITLE
fix(pull_request): use server-side labels instead of payload

### DIFF
--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -840,7 +840,14 @@ describe('handlePullRequest', () => {
       filterLabels: { include: ['test_label'] },
     } as any
 
-    context.payload.pull_request.labels = [{ name: 'some_label' }]
+    // MOCKS
+    client.pulls = {
+      get: jest.fn().mockImplementation(async () => ({
+        data: {
+          labels: [{ name: 'some_label' }],
+        },
+      })),
+    } as any
 
     await handler.handlePullRequest(client, context, config)
 
@@ -857,12 +864,20 @@ describe('handlePullRequest', () => {
       filterLabels: { include: ['test_label'], exclude: ['wip'] },
     } as any
 
-    context.payload.pull_request.labels = [
-      { name: 'test_label' },
-      { name: 'wip' },
-    ]
+    // MOCKS
+    client.pulls = {
+      get: jest.fn().mockImplementation(async () => ({
+        data: {
+          labels: [{ name: 'test_label' }, { name: 'wip' }],
+        },
+      })),
+    } as any
 
-    await handler.handlePullRequest(client, context, config)
+    context.payload.pull_request.labels = await handler.handlePullRequest(
+      client,
+      context,
+      config
+    )
 
     expect(spy.mock.calls[0][0]).toEqual(
       'Skips the process to add reviewers/assignees since PR is tagged with any of the filterLabels.exclude'
@@ -880,9 +895,13 @@ describe('handlePullRequest', () => {
 
     const client = new github.GitHub('token')
 
-    context.payload.pull_request.labels = [{ name: 'some_label' }]
-
+    // MOCKS
     client.pulls = {
+      get: jest.fn().mockImplementation(async () => ({
+        data: {
+          labels: [{ name: 'some_label' }],
+        },
+      })),
       createReviewRequest: jest.fn().mockImplementation(async () => {}),
     } as any
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -75,7 +75,7 @@ export async function handlePullRequest(
 
   if (filterLabels !== undefined) {
     if (filterLabels.include !== undefined && filterLabels.include.length > 0) {
-      const hasLabels = pr.hasAnyLabel(filterLabels.include)
+      const hasLabels = await pr.hasAnyLabel(filterLabels.include)
       if (!hasLabels) {
         core.info(
           'Skips the process to add reviewers/assignees since PR is not tagged with any of the filterLabels.include'
@@ -85,7 +85,7 @@ export async function handlePullRequest(
     }
 
     if (filterLabels.exclude !== undefined && filterLabels.exclude.length > 0) {
-      const hasLabels = pr.hasAnyLabel(filterLabels.exclude)
+      const hasLabels = await pr.hasAnyLabel(filterLabels.exclude)
       if (hasLabels) {
         core.info(
           'Skips the process to add reviewers/assignees since PR is tagged with any of the filterLabels.exclude'

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -33,11 +33,21 @@ export class PullRequest {
     core.debug(JSON.stringify(result))
   }
 
-  hasAnyLabel(labels: string[]): boolean {
-    if (!this.context.payload.pull_request) {
+  async hasAnyLabel(labels: string[]): Promise<boolean> {
+    const { owner, repo, number: pull_number } = this.context.issue
+
+    const pull = await this.client.pulls.get({
+      owner,
+      repo,
+      pull_number,
+    })
+
+    if (pull == null) {
       return false
     }
-    const { labels: pullRequestLabels = [] } = this.context.payload.pull_request
-    return pullRequestLabels.some(label => labels.includes(label.name))
+
+    const { labels: prLabels = [] } = pull.data
+
+    return prLabels.some(label => labels.includes(label.name))
   }
 }


### PR DESCRIPTION
GH Workflow:

PR Opened -> Bot Adds Labels -> Add Reviewers

3rd step is not possible using the data provided when a PR is opened. 

By using `octokit` to retrieve the latest data we can satisfy the above workflow while not breaking compatbility for prior use-cases.