### PR TITLE
fix(choose-users): make usernames case insensitive

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,7 @@ export function chooseUsers(
   filterUser: string = ''
 ): string[] {
   const filteredCandidates = candidates.filter((reviewer: string): boolean => {
-    return reviewer !== filterUser
+    return reviewer.toLowerCase() !== filterUser.toLowerCase()
   })
 
   // all-assign


### PR DESCRIPTION
When attempting to implement this action I ran into the same issue as #11 .

This PR makes usernames case insensitive when filtering. 