### PR TITLE
Allow to enforce that reviewers and assignees are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ useAssigneeGroups: false
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 # skipKeywords:
 #   - wip
+
+# Set to true to enforce that reviewers and assignees are different
+skipReviewersAsAssignees: false
 ```
 
 ### Assign Author as Assignee

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -21,6 +21,7 @@ export interface Config {
   useAssigneeGroups: boolean
   reviewGroups: { [key: string]: string[] }
   assigneeGroups: { [key: string]: string[] }
+  skipReviewersAsAssignees: boolean
   runOnDraft?: boolean
 }
 
@@ -45,6 +46,7 @@ export async function handlePullRequest(
     addAssignees,
     filterLabels,
     runOnDraft,
+    skipReviewersAsAssignees,
   } = config
 
   if (skipKeywords && utils.includesSkipKeywords(title, skipKeywords)) {
@@ -114,7 +116,8 @@ export async function handlePullRequest(
 
   if (addAssignees) {
     try {
-      const assignees = utils.chooseAssignees(owner, config)
+      const excluded = skipReviewersAsAssignees ? config.reviewers : []
+      const assignees = utils.chooseAssignees(owner, config, excluded)
 
       if (assignees.length > 0) {
         await pr.addAssignees(assignees)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,13 +16,17 @@ export function chooseReviewers(owner: string, config: Config): string[] {
       numberOfReviewers
     )
   } else {
-    chosenReviewers = chooseUsers(reviewers, numberOfReviewers, owner)
+    chosenReviewers = chooseUsers(reviewers, numberOfReviewers, [owner])
   }
 
   return chosenReviewers
 }
 
-export function chooseAssignees(owner: string, config: Config): string[] {
+export function chooseAssignees(
+  owner: string,
+  config: Config,
+  excluded: string[]
+): string[] {
   const {
     useAssigneeGroups,
     assigneeGroups,
@@ -55,7 +59,7 @@ export function chooseAssignees(owner: string, config: Config): string[] {
     chosenAssignees = chooseUsers(
       candidates,
       numberOfAssignees || numberOfReviewers,
-      owner
+      [owner, ...excluded]
     )
   }
 
@@ -65,10 +69,13 @@ export function chooseAssignees(owner: string, config: Config): string[] {
 export function chooseUsers(
   candidates: string[],
   desiredNumber: number,
-  filterUser: string = ''
+  filterUser: string[] = []
 ): string[] {
+  const excludedLower = filterUser.map((user: string): string => {
+    return user.toLowerCase()
+  })
   const filteredCandidates = candidates.filter((reviewer: string): boolean => {
-    return reviewer.toLowerCase() !== filterUser.toLowerCase()
+    return excludedLower.indexOf(reviewer.toLowerCase()) !== -1
   })
 
   // all-assign
@@ -99,7 +106,7 @@ export function chooseUsersFromGroups(
 ): string[] {
   let users: string[] = []
   for (const group in groups) {
-    users = users.concat(chooseUsers(groups[group], desiredNumber, owner))
+    users = users.concat(chooseUsers(groups[group], desiredNumber, [owner]))
   }
   return users
 }


### PR DESCRIPTION
Add a new parameter to ensure that the people cannot be both "reviewer" and "assignee" at the same time.

```yaml
# Set to true to enforce that reviewers and assignees are different
skipReviewersAsAssignees: false
```