### PR TITLE
feat: add support for team reviewers in pull requests configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@ reviewers:
   - reviewerB
   - reviewerC
 
+# A list of team reviewers to be added to pull requests (GitHub team slug)
+teamReviewers:
+  - teamA
+  - teamB
+
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
 numberOfReviewers: 0
+
+# A number of team reviewers added to the pull request
+# Set 0 to add all the team reviewers (default: 0)
+numberOfTeamReviewers: 0
+
 # A list of assignees, overrides reviewers if set
 # assignees:
 #   - assigneeA
@@ -93,6 +103,10 @@ addAssignees: false
 # Set 0 to add all the reviewers (default: 0)
 numberOfReviewers: 1
 
+# A number of team reviewers added to the pull request  
+# Set 0 to add all the team reviewers (default: 0)
+numberOfTeamReviewers: 1
+
 # A number of assignees to add to the pull request
 # Set to 0 to add all of the assignees.
 # Uses numberOfReviewers if unset.
@@ -111,6 +125,18 @@ reviewGroups:
     - reviewerD
     - reviewerE
     - reviewerF
+
+# Set to true to add team reviewers from different groups to pull requests
+useTeamReviewGroups: true
+
+# A list of team reviewers, split into different groups, to be added to pull requests (GitHub team slug)
+teamReviewGroups:
+  frontend:
+    - frontend-team
+    - ui-team
+  backend:
+    - backend-team
+    - api-team
 
 # Set to true to add assignees from different groups to pull requests
 useAssigneeGroups: false

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   chooseUsers,
   chooseUsersFromGroups,
+  chooseTeamReviewers,
   includesSkipKeywords,
   fetchConfigurationFile,
 } from '../src/utils'
@@ -240,5 +241,79 @@ describe('fetchConfigurationFile', () => {
         ref: 'sha',
       })
     ).rejects.toThrow(/the configuration file is not found/)
+  })
+})
+
+describe('chooseTeamReviewers', () => {
+  test('returns team reviewers without PR creator', () => {
+    const owner = 'pr-creator'
+    const config = {
+      teamReviewers: ['team1', 'team2', 'team3'],
+      numberOfTeamReviewers: 0,
+      useTeamReviewGroups: false,
+      teamReviewGroups: {},
+    } as any
+
+    const list = chooseTeamReviewers(owner, config)
+
+    expect(list).toEqual(['team1', 'team2', 'team3'])
+  })
+
+  test('returns limited number of team reviewers', () => {
+    const owner = 'pr-creator'
+    const config = {
+      teamReviewers: ['team1', 'team2', 'team3'],
+      numberOfTeamReviewers: 2,
+      useTeamReviewGroups: false,
+      teamReviewGroups: {},
+    } as any
+
+    const list = chooseTeamReviewers(owner, config)
+
+    expect(list.length).toEqual(2)
+  })
+
+  test('returns empty array when no team reviewers configured', () => {
+    const owner = 'pr-creator'
+    const config = {
+      teamReviewers: [],
+      numberOfTeamReviewers: 0,
+      useTeamReviewGroups: false,
+      teamReviewGroups: {},
+    } as any
+
+    const list = chooseTeamReviewers(owner, config)
+
+    expect(list.length).toEqual(0)
+  })
+
+  test('returns team reviewers from groups when useTeamReviewGroups is true', () => {
+    const owner = 'pr-creator'
+    const config = {
+      teamReviewers: [],
+      numberOfTeamReviewers: 1,
+      useTeamReviewGroups: true,
+      teamReviewGroups: {
+        frontend: ['frontend-team'],
+        backend: ['backend-team'],
+      },
+    } as any
+
+    const list = chooseTeamReviewers(owner, config)
+
+    expect(list.length).toEqual(2)
+  })
+
+  test('handles undefined teamReviewers gracefully', () => {
+    const owner = 'pr-creator'
+    const config = {
+      numberOfTeamReviewers: 0,
+      useTeamReviewGroups: false,
+      teamReviewGroups: {},
+    } as any
+
+    const list = chooseTeamReviewers(owner, config)
+
+    expect(list.length).toEqual(0)
   })
 })

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -11,14 +11,26 @@ export class PullRequest {
     this.context = context
   }
 
-  async addReviewers(reviewers: string[]): Promise<void> {
+  async addReviewers(
+    reviewers: string[],
+    teamReviewers: string[] = []
+  ): Promise<void> {
     const { owner, repo, number: pull_number } = this.context.issue
-    const result = await this.client.rest.pulls.requestReviewers({
+    const requestData: any = {
       owner,
       repo,
       pull_number,
-      reviewers,
-    })
+    }
+
+    if (reviewers.length > 0) {
+      requestData.reviewers = reviewers
+    }
+
+    if (teamReviewers.length > 0) {
+      requestData.team_reviewers = teamReviewers
+    }
+
+    const result = await this.client.rest.pulls.requestReviewers(requestData)
     core.debug(JSON.stringify(result))
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,34 @@ export function chooseReviewers(owner: string, config: Config): string[] {
   return chosenReviewers
 }
 
+export function chooseTeamReviewers(owner: string, config: Config): string[] {
+  const {
+    useTeamReviewGroups,
+    teamReviewGroups,
+    numberOfTeamReviewers,
+    teamReviewers,
+  } = config
+  let chosenTeamReviewers: string[] = []
+  const useGroups: boolean =
+    useTeamReviewGroups && Object.keys(teamReviewGroups).length > 0
+
+  if (useGroups) {
+    chosenTeamReviewers = chooseUsersFromGroups(
+      owner,
+      teamReviewGroups,
+      numberOfTeamReviewers
+    )
+  } else {
+    chosenTeamReviewers = chooseUsers(
+      teamReviewers || [],
+      numberOfTeamReviewers,
+      owner
+    )
+  }
+
+  return chosenTeamReviewers
+}
+
 export function chooseAssignees(owner: string, config: Config): string[] {
   const {
     useAssigneeGroups,


### PR DESCRIPTION
This pull request adds support for assigning GitHub team reviewers to pull requests, both as a flat list and via grouped teams, and introduces related configuration options and test coverage. The changes affect the configuration schema, handler logic, utility functions, and tests to ensure team reviewers are handled correctly alongside individual reviewers.

**Configuration enhancements:**

* Added `teamReviewers`, `numberOfTeamReviewers`, `useTeamReviewGroups`, and `teamReviewGroups` options to the configuration schema and documented them in `README.md`, allowing specification of team reviewers and grouping by team. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R109) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R140) [[4]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R12-R26)

**Handler and logic updates:**

* Updated `handlePullRequest` in `src/handler.ts` to select and add team reviewers, including error handling when `useTeamReviewGroups` is enabled but `teamReviewGroups` is missing. [[1]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R46-R48) [[2]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R75-R80) [[3]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R115-R127)

* Modified `PullRequest.addReviewers` in `src/pull_request.ts` to accept both individual and team reviewers and send both in the API request.

**Utility function additions:**

* Added `chooseTeamReviewers` to `src/utils.ts` to select team reviewers based on configuration, supporting both flat and grouped team selection.

**Test coverage improvements:**

* Added unit tests for `chooseTeamReviewers` in `__tests__/utils.test.ts` and expanded `handlePullRequest` tests in `__tests__/handler.test.ts` to cover team reviewer logic, including error cases and group selection. [[1]](diffhunk://#diff-9f2fb172b8d9503044ee436e37d9b204964fabb3b8cd9d1adf2827e8618e26b2R4) [[2]](diffhunk://#diff-9f2fb172b8d9503044ee436e37d9b204964fabb3b8cd9d1adf2827e8618e26b2R246-R319) [[3]](diffhunk://#diff-950cf938f07ecc88a7bec7a10901d6b48e69b76a060245306e6e8929a6a421f7R982-R1170)